### PR TITLE
fix: move diff to content

### DIFF
--- a/server/agent/prompts/pull_request.py
+++ b/server/agent/prompts/pull_request.py
@@ -48,9 +48,6 @@ Review the diff for any errors or vulnerabilities in the updated files. Focus on
 - The + sign means that code has been added.
 - The - sign means that code has been removed.
 
-## File Diff:
-{file_diff}
-
 # Constraints
 - Only create comments for significant issues, such as potential logical errors, vulnerabilities, or functionality-impacting bugs and typo.
 - Absolutely avoid commenting on or evaluating any files that were not part of the current changeset (no diffs). This includes any files in the repository that have not been modified as part of the pull request.
@@ -63,12 +60,11 @@ Review the diff for any errors or vulnerabilities in the updated files. Focus on
 
 
 def get_role_prompt(
-    repo_name: str, pull_number: int, title: str, description: str, file_diff: str
+    repo_name: str, pull_number: int, title: str, description: str
 ):
     return PULL_REQUEST_ROLE.format(
         repo_name=repo_name,
         pull_number=pull_number,
         title=title,
         description=description,
-        file_diff=file_diff,
     )

--- a/server/bot/builder.py
+++ b/server/bot/builder.py
@@ -47,7 +47,8 @@ async def bot_info_generator(
                 else "我是你专属的答疑机器人，你可以问我关于当前项目的任何问题~"
             ),
             "repo_name": repo_name,
-            "llm": "openai"
+            "llm": "openai",
+            "token_id": ""
         }
 
         return bot_data

--- a/server/event_handler/pull_request.py
+++ b/server/event_handler/pull_request.py
@@ -83,7 +83,7 @@ class PullRequestEventHandler:
 
                 file_diff = self.get_file_diff(diff)
                 role_prompt = get_role_prompt(
-                    repo.full_name, pr.number, pr.title, pr.body, file_diff
+                    repo.full_name, pr.number, pr.title, pr.body
                 )
 
                 print(f"file_diff={file_diff}")
@@ -92,6 +92,8 @@ class PullRequestEventHandler:
                 {pr.title}
                 ### Pr Description
                 {pr.body}
+                ### File Diff
+                {file_diff}
                 """
                 origin_bot = get_bot_by_id(repo_config.robot_id)
 


### PR DESCRIPTION
- move filediff from role prompt to content
- avoid template replacement issue 
```
Single '}' encountered in format string
```