### PR TITLE
revert(get_user_repos_installed_app): Rollback the method for obtaining a user's GitHub organization.

### DIFF
--- a/server/github_app/router.py
+++ b/server/github_app/router.py
@@ -131,7 +131,7 @@ async def github_app_webhook(
 
 
 @router.get("/user/repos_installed_app")
-def get_user_repos_installed_app_(
+def get_user_repos_installed_app(
     user: Annotated[User | None, Depends(get_user)] = None
 ):
     """
@@ -146,7 +146,7 @@ def get_user_repos_installed_app_(
         auth = Auth.Token(token=user.access_token)
         g = Github(auth=auth)
         github_user = g.get_user()
-        orgs = get_user_orgs(github_user.login, auth.token)
+        orgs = github_user.get_orgs()
         repository_config_dao = RepositoryConfigDAO()
         installations = repository_config_dao.query_by_owners(
             [org.id for org in orgs] + [github_user.id]


### PR DESCRIPTION
issue：https://github.com/petercat-ai/petercat/issues/537