### PR TITLE
feat(deployment): add a prompt for authorizing the github organiztion

### DIFF
--- a/client/.kiwi/en/DeployBotModal.ts
+++ b/client/.kiwi/en/DeployBotModal.ts
@@ -19,6 +19,9 @@ export default {
     ninDeJiQiRen:
       'Your robot has been made public in the marketplace, please check it out in the market.',
     gongKaiDaoPE: 'Publish to the PeterCat Marketplace',
+    meiZhaoDaoXiangYao:"Can't find the repository with PeterCat Assistant installed? ",
+    dianJiCiChu:'Click here',
+    shouQuanAnZhuangG:"Authorize organization for PeterCat"
   },
   DeployItem: {
     shouQi: 'Collapse',

--- a/client/.kiwi/en/DeployBotModal.ts
+++ b/client/.kiwi/en/DeployBotModal.ts
@@ -20,7 +20,7 @@ export default {
       'Your robot has been made public in the marketplace, please check it out in the market.',
     gongKaiDaoPE: 'Publish to the PeterCat Marketplace',
     meiZhaoDaoXiangYao:"Can't find the repository with PeterCat Assistant installed? ",
-    dianJiCiChu:'Click here',
+    dianJiCiChu:'Click here ',
     shouQuanAnZhuangG:"Authorize organization for PeterCat"
   },
   DeployItem: {

--- a/client/.kiwi/ja/DeployBotModal.ts
+++ b/client/.kiwi/ja/DeployBotModal.ts
@@ -18,6 +18,9 @@ export default {
     ninDeJiQiRen:
       'あなたのロボットはすでに市場に公開されています。市場をご覧ください。',
     gongKaiDaoPE: 'Peter Cat市場に公開',
+    meiZhaoDaoXiangYao:'PeterCat Assistant がインストールされたリポジトリが見つかりませんか？',
+    dianJiCiChu:'こちらをクリック',
+    shouQuanAnZhuangG:'PeterCat に組織を承認'
   },
   DeployItem: {
     shouQi: '折りたたむ',

--- a/client/.kiwi/ko/DeployBotModal.ts
+++ b/client/.kiwi/ko/DeployBotModal.ts
@@ -16,6 +16,9 @@ export default {
       '이것은 PeterCat 저장소에 issue를 제출하게 되며, 우리 인공 검토를 통과하면 공개될 수 있습니다.',
     ninDeJiQiRen: '당신의 봇이 시장에 공개되었습니다. 시장을 확인해 보세요.',
     gongKaiDaoPE: 'PeterCat 시장에 공개',
+    meiZhaoDaoXiangYao:'PeterCat Assistant가 설치된 저장소를 찾을 수 없습니까?',
+    dianJiCiChu:'여기를 클릭하세요',
+    shouQuanAnZhuangG:'PeterCat에 조직 권한 부여'
   },
   DeployItem: {
     shouQi: '접기',

--- a/client/.kiwi/zh-CN/DeployBotModal.ts
+++ b/client/.kiwi/zh-CN/DeployBotModal.ts
@@ -16,6 +16,9 @@ export default {
       '这将提交一个 issue 到 PeterCat\n                  仓库，待我们人工审核通过后即可完成公开。',
     ninDeJiQiRen: '您的机器人已经公开到了市场，请前往市场查看。',
     gongKaiDaoPE: '公开到 PeterCat 市场',
+    meiZhaoDaoXiangYao:"没找到已安装 PeterCat Assistant 机器人的仓库？",
+    dianJiCiChu:'点击此处',
+    shouQuanAnZhuangG:"授权组织给 PeterCat"
   },
   DeployItem: {
     shouQi: '收起',

--- a/client/.kiwi/zh-TW/DeployBotModal.ts
+++ b/client/.kiwi/zh-TW/DeployBotModal.ts
@@ -16,6 +16,9 @@ export default {
       '這將提交一個 issue 到 PeterCat 倉庫，待我們人工審核通過後即可完成公開。',
     ninDeJiQiRen: '您的機器人已經公開到了市場，請前往市場查看。',
     gongKaiDaoPE: '公開到 PeterCat 市場',
+    meiZhaoDaoXiangYao:"找不到已安裝 PeterCat Assistant 的倉庫",
+    dianJiCiChu:'點擊此處',
+    shouQuanAnZhuangG:"授權組織給 PeterCat"
   },
   DeployItem: {
     shouQi: '收起',

--- a/client/app/factory/edit/components/DeployBotModal/DeployContent.tsx
+++ b/client/app/factory/edit/components/DeployBotModal/DeployContent.tsx
@@ -218,6 +218,13 @@ export const DeployContent: React.FC<IDeployContentProps> = ({
               <span>{I18N.DeployBotModal.DeployContent.shuaXin}</span>
             </div>
           )}
+          <div className="font-PingFangSC underline-none text-[#6B7280] mt-[16px]">
+            {I18N.DeployBotModal.DeployContent.meiZhaoDaoXiangYao}<a
+              href="https://github.com/settings/connections/applications/Ov23liiNROqv6drzyqhU"
+              target="_blank"
+            >
+              {I18N.DeployBotModal.DeployContent.dianJiCiChu}</a>
+            {I18N.DeployBotModal.DeployContent.shouQuanAnZhuangG}</div>
         </div>
       </DeployItem>
     );

--- a/client/app/factory/edit/components/DeployBotModal/index.tsx
+++ b/client/app/factory/edit/components/DeployBotModal/index.tsx
@@ -276,10 +276,11 @@ const MyBotDeployModal: React.FC<IModalProps> = ({ isOpen, onClose }) => {
   return (
     <>
       <Modal
-        isDismissable={false}
+        isDismissable={true}
+        isKeyboardDismissDisabled={true}
         isOpen={isOpen}
+        size="xl"
         onClose={onClose}
-        hideCloseButton={true}
       >
         <ModalContent>
           {(onClose) => (

--- a/client/kiwi-config.json
+++ b/client/kiwi-config.json
@@ -1,9 +1,7 @@
 {
   "fileType": "ts",
   "srcLang": "zh-CN",
-  "distLangs": [
-    "en-US"
-  ],
+  "distLangs": ["en-US"],
   "googleApiKey": "",
   "baiduApiKey": {
     "appId": "",
@@ -19,5 +17,8 @@
   "defaultTranslateKeyApi": "Pinyin",
   "importI18N": "import I18N from '@/app/utils/I18N';",
   "ignoreDir": [],
-  "ignoreFile": ["client/components/LangSwitcher.tsx"]
+  "ignoreFile": [
+    "client/components/LangSwitcher.tsx",
+    "client/app/contexts/GlobalContext.tsx"
+  ]
 }


### PR DESCRIPTION
Added a prompt for authorizing the Petercat OAuth for the GitHub organization under the list of repositories for deployable bots.
![image](https://github.com/user-attachments/assets/8ce6dccd-39e7-493a-ac2d-2014b3548766)
