### PR TITLE
refactor: update import statements for loading animations in Chat components to avoid leaking require statement into bundled esm file

### DIFF
--- a/assistant/src/Chat/components/LoadingEnd.tsx
+++ b/assistant/src/Chat/components/LoadingEnd.tsx
@@ -1,7 +1,7 @@
 import Lottie from 'lottie-react';
 import React, { useState } from 'react';
 
-const LoadingAnimationEnd = require('../../assets/bubble-end.json');
+import LoadingAnimationEnd from '../../assets/bubble-end.json';
 
 interface LoadingEndProps {
   children?: React.ReactNode;

--- a/assistant/src/Chat/components/LoadingStart.tsx
+++ b/assistant/src/Chat/components/LoadingStart.tsx
@@ -1,6 +1,6 @@
 import Lottie from 'lottie-react';
 import React from 'react';
-const LoadingAnimationStart = require('../../assets/bubble-start.json');
+import LoadingAnimationStart from '../../assets/bubble-start.json';
 
 interface LoadingStartProps {
   loop?: boolean;


### PR DESCRIPTION
## 问题描述

dumi构建assistant的esm时并未将require语句转换成import语句，导致第3方用户使用vite构建时报错。

由于不知道怎么配置dumi，就直接改了源代码，建议dumi配置也加上，在esm模式下将require语句转换成import语句

## 错误截图

<img width="721" alt="image" src="https://github.com/user-attachments/assets/21ded193-77d8-444d-9fed-d4fc88dafe46" />

<img width="556" alt="image" src="https://github.com/user-attachments/assets/ae63a8ac-7273-4192-8d3b-97c1498f8a9d" />
