### PR TITLE
fix: enable standalone output in Next.js configuration

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -39,6 +39,7 @@ module.exports = withSentryConfig(nextConfig, {
 });
 
 module.exports = {
+  output: "standalone",
   webpack: (config) => {
     config.module.rules.push({
       test: /\.md$/,


### PR DESCRIPTION
If output: "standalone" is not included in module.exports, the standalone folder will not be generated successfully.